### PR TITLE
if-switch: move antenna 1h to switch 1

### DIFF
--- a/grc/ata_ifswitch.block.yml
+++ b/grc/ata_ifswitch.block.yml
@@ -11,12 +11,12 @@ parameters:
 - id: ant1
   label: Switch 1 Antennas
   dtype: string
-  options: [none, 1a, 1b, 1c, 1d, 1e, 1f, 1g, 1k, 2a, 2b, 2c, 2d, 2e, 2f, 2g, 2h]
+  options: [none, 1a, 1h, 1c, 1d, 1e, 1f, 1g, 1k, 2a, 2b, 2c, 2d, 2e, 2f, 2g, 2h]
   
 - id: ant2
   label: Switch 2 Antennas
   dtype: string
-  options: [none, 1h, 2j, 2k, 2l, 3c, 3e, 3j, 3l, 4g]
+  options: [none, 2j, 2k, 2l, 3c, 3e, 3j, 3l, 4g]
   
 - id: ant3 
   label: Switch 3 Antennas


### PR DESCRIPTION
The list of antenna assignments to switches is in
https://github.com/SETIatHCRO/ATA-Utils/blob/master/RFSwitchUtils/antassign.h#L21
Antenna 1h belongs to switch 1, but was entered in switch 2 in
787420b5307803e78705e60478df4f49cde9e13d