### PR TITLE
Update antenna list and alarm

### DIFF
--- a/grc/ata_ifswitch.block.yml
+++ b/grc/ata_ifswitch.block.yml
@@ -11,17 +11,17 @@ parameters:
 - id: ant1
   label: Switch 1 Antennas
   dtype: string
-  options: [none, 1a, 1h, 1c, 1d, 1e, 1f, 1g, 1k, 2a, 2b, 2c, 2d, 2e, 2f, 2g, 2h]
+  options: [none, 1a, 1c, 2a, 2b, 2e, 2c, 3e, 3j, 3l, 4g, 4j, 4l, 5b, 5e, 5g, 5h]
   
 - id: ant2
   label: Switch 2 Antennas
   dtype: string
-  options: [none, 2j, 2k, 2l, 3c, 3e, 3j, 3l, 4g]
+  options: [none, 1f, 1h, 1k, 2j, 2h, 2m, 3c, 5c]
   
 - id: ant3 
   label: Switch 3 Antennas
   dtype: string
-  options: [none, 4j, 4k, 4l, 5b, 5c, 5e, 5g, 5h]
+  options: [none]
   
 #- id: db1
 #  label: Atten. for Switch 1 (dB)

--- a/python/control.py
+++ b/python/control.py
@@ -74,21 +74,10 @@ class control(gr.basic_block):
             ping_success = "1 packets transmitted, 1 received"
 
             if ping_success in ping_output:
-                try:
-                    alarm = ac.get_alarm()
-
-                    if alarm['user'] == username:
-                        self.is_user = True
-                        print("You are the primary user. You have full permissions.")
-
-                    else:
-                        self.is_user = False
-                        raise Exception("Another user, {0}, has the array locked out. \n"
-                                        "You do not have permission to observe.".format(alarm['user']))
-                except KeyError:
-                    self.is_user = False
-                    raise Exception("The array is not locked out under your username.\n"
-                                    "You do not have permission to observe.")
+                # TODO: reserve antennas here by moving them to the 'atagr'
+                # group. However this is not trivial, because we do not know
+                # in this block the antennas that we will use.
+                self.is_user = True
 
                 self.message_port_register_in(pmt.intern("command"))
                 self.set_msg_handler(pmt.intern("command"), self.handle_msg)


### PR DESCRIPTION
This updates the list of antennas available in the IF switch and also also disables the alarm, since it is no longer used.

As a future work, to replace the alarm, the antennas should be reserved by doing `ac.move_ant_group(antennas, 'none', 'atagr')` and freed by doing `ac.move_ant_group(antennas, 'atagr', 'none')`. However, some work needs to be done to integrate these changes, since the control block does not currently have access to the list of antennas to use when it is instanced.