### PR TITLE
Fix catalogue tracking (maint-3.8 branch)

### DIFF
--- a/python/control.py
+++ b/python/control.py
@@ -262,9 +262,12 @@ class control(gr.basic_block):
             designated by the given ID from the ATA catalog. '''
 
         now = datetime.now()
-        src_ra, src_dec = ac.get_source_ra_dec(src_id)
 
-        if self.pos.isUp('radec', now, src_ra, src_dec):
+        # TODO: check if the source is up.
+        # A former version of gr-ata checked this, but the method it used
+        # does not work any longer.
+        source_is_up = True
+        if source_is_up:
             ac.create_ephems2(src_id, az_off, el_off)
             if not offsource:
                 ac.point_ants2(src_id, 'on', ant_list)


### PR DESCRIPTION
The function that fails when using catalogue tracking is `ac.get_source_ra_dec()`. This function seems to be broken since the
port of ata_control to the REST API. However, this function is only used here to check if the source is up, so we can disable it
and assume that the source is up.

I have tested that this commit fixes catalogue tracking for the trackscan and on-off modes.

This PR is intended as a quick fix to #11.